### PR TITLE
EDUCATOR - 1714

### DIFF
--- a/cms/templates/js/course-outline.underscore
+++ b/cms/templates/js/course-outline.underscore
@@ -218,7 +218,7 @@ if (is_proctored_exam) {
                          -
                         <span class="sr status-proctored-exam-label"> <%- exam_value %> </span>
                         <span class="status-proctored-exam-value"> <%- exam_value %> </span>
-                        <% if (xblockInfo.get('due_date')) { %>
+                        <% if (xblockInfo.get('due_date') && !course.get('self_paced')) { %>
                             <span class="status-grading-date"> <%- gettext('Due:') %> <%- xblockInfo.get('due_date') %> </span>
                         <% } %>
                     </p>

--- a/common/test/acceptance/tests/studio/test_studio_outline.py
+++ b/common/test/acceptance/tests/studio/test_studio_outline.py
@@ -1829,11 +1829,6 @@ class SelfPacedOutlineTest(CourseOutlineTest):
             'start_date': datetime.now() + timedelta(days=1),
 
         })
-        self.course_fixture.add_advanced_settings({
-            'enable_timed_exams': {
-                'value': True
-            }
-        })
         ConfigModelFixture('/config/self_paced', {'enabled': True}).install()
 
     def test_release_dates_not_shown(self):
@@ -1878,7 +1873,6 @@ class InstructorPacedToSelfPacedOutlineTest(CourseOutlineTest):
     Test the course outline when pacing is changed from
     instructor to self paced.
     """
-
     def populate_course_fixture(self, course_fixture):
         course_fixture.add_children(
             XBlockFixtureDesc('chapter', SECTION_NAME).add_children(
@@ -1889,22 +1883,18 @@ class InstructorPacedToSelfPacedOutlineTest(CourseOutlineTest):
         )
         self.course_fixture.add_course_details({
             'start_date': datetime.now() + timedelta(days=1),
-
         })
         self.course_fixture.add_advanced_settings({
             'enable_timed_exams': {
                 'value': True
             }
         })
-
     def test_due_dates_not_shown(self):
         """
         Related to EDUCATOR 1714: (https://openedx.atlassian.net/browse/EDUCATOR-1714)
         Scenario: Ensure that due dates for timed exams
             are not displayed on the course outline page when switched to
             self-paced mode from instructor-paced.
-
-
         Given an instructor paced course, add a due date for a subsection.
         Change the course's pacing to self-paced.
         Add the timed exam on the subsection on whom the due date was added.
@@ -1915,7 +1905,8 @@ class InstructorPacedToSelfPacedOutlineTest(CourseOutlineTest):
         subsection = section.subsection(SUBSECTION_NAME)
         modal = subsection.edit()
         modal.due_date = '5/14/2016'
-
+        self.course_outline_page.select_advanced_tab()
+        self.course_outline_page.make_exam_timed()
         modal.save()
         # Checking if the added due date saved
         self.assertIn('May 14', subsection.due_date)
@@ -1925,7 +1916,6 @@ class InstructorPacedToSelfPacedOutlineTest(CourseOutlineTest):
         })
         # configure call to actually update course with new settings
         self.course_fixture.configure_course()
-        self.course_outline_page.make_exam_timed()
         # Reloading page after the changes
         self.course_outline_page.visit()
         self.assertIsNone(subsection.due_date)


### PR DESCRIPTION
EDUCATOR-1714: Subsections (in Studio) can inaccurately display due dates in self-paced courses if the assignment is timed.

Fix: xblocks are the standalone modules that aren't directly linked to courses; rather courses are made up of xblocks. The information if the course is self-paced/instructor-paced is present inside the course overview object. xblocks contain information about the due date. On the front-end of the studio; we have access to both course and its xblocks (course-outline.underscore file). In the file, an additional check on the due dates has been added; where they are displayed only if the course is instructor-paced.
